### PR TITLE
feat(frontend): migrate cookies/headers APIs to async

### DIFF
--- a/autogpt_platform/frontend/pnpm-workspace.yaml
+++ b/autogpt_platform/frontend/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 onlyBuiltDependencies:
-  - '@scarf/scarf'
-  - '@sentry/cli'
-  - '@swc/core'
+  - "@scarf/scarf"
+  - "@sentry/cli"
+  - "@swc/core"
   - core-js-pure
   - esbuild
   - msw

--- a/autogpt_platform/frontend/src/app/(platform)/auth/callback/route.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/auth/callback/route.ts
@@ -9,7 +9,7 @@ export async function GET(request: Request) {
   const next = searchParams.get("next") ?? "/";
 
   if (code) {
-    const supabase = getServerSupabase();
+    const supabase = await getServerSupabase();
 
     if (!supabase) {
       return NextResponse.redirect(`${origin}/error`);

--- a/autogpt_platform/frontend/src/app/(platform)/auth/confirm/route.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/auth/confirm/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
   const next = searchParams.get("next") ?? "/";
 
   if (token_hash && type) {
-    const supabase = getServerSupabase();
+    const supabase = await getServerSupabase();
 
     if (!supabase) {
       redirect("/error");

--- a/autogpt_platform/frontend/src/app/(platform)/login/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/login/actions.ts
@@ -21,7 +21,7 @@ export async function login(
   turnstileToken: string,
 ) {
   return await Sentry.withServerActionInstrumentation("login", {}, async () => {
-    const supabase = getServerSupabase();
+    const supabase = await getServerSupabase();
     const api = new BackendAPI();
 
     if (!supabase) {
@@ -60,7 +60,7 @@ export async function providerLogin(provider: LoginProvider) {
     "providerLogin",
     {},
     async () => {
-      const supabase = getServerSupabase();
+      const supabase = await getServerSupabase();
       const api = new BackendAPI();
 
       if (!supabase) {

--- a/autogpt_platform/frontend/src/app/(platform)/profile/(user)/settings/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/profile/(user)/settings/actions.ts
@@ -6,7 +6,7 @@ import BackendApi from "@/lib/autogpt-server-api";
 import { NotificationPreferenceDTO } from "@/lib/autogpt-server-api/types";
 
 export async function updateSettings(formData: FormData) {
-  const supabase = getServerSupabase();
+  const supabase = await getServerSupabase();
   const {
     data: { user },
   } = await supabase.auth.getUser();

--- a/autogpt_platform/frontend/src/app/(platform)/reset_password/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/reset_password/actions.ts
@@ -10,7 +10,7 @@ export async function sendResetEmail(email: string, turnstileToken: string) {
     "sendResetEmail",
     {},
     async () => {
-      const supabase = getServerSupabase();
+      const supabase = await getServerSupabase();
       const headersList = await headers();
       const host = headersList.get("host");
       const protocol =
@@ -49,7 +49,7 @@ export async function changePassword(password: string, turnstileToken: string) {
     "changePassword",
     {},
     async () => {
-      const supabase = getServerSupabase();
+      const supabase = await getServerSupabase();
 
       if (!supabase) {
         redirect("/error");

--- a/autogpt_platform/frontend/src/app/(platform)/signup/actions.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/signup/actions.ts
@@ -17,7 +17,7 @@ export async function signup(
     "signup",
     {},
     async () => {
-      const supabase = getServerSupabase();
+      const supabase = await getServerSupabase();
 
       if (!supabase) {
         redirect("/error");

--- a/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
+++ b/autogpt_platform/frontend/src/lib/autogpt-server-api/client.ts
@@ -86,21 +86,22 @@ export default class BackendAPI {
     this.wsUrl = wsUrl;
   }
 
-  private get supabaseClient(): SupabaseClient | null {
+  private async getSupabaseClient(): Promise<SupabaseClient | null> {
     return isClient
       ? createBrowserClient(
           process.env.NEXT_PUBLIC_SUPABASE_URL!,
           process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
           { isSingleton: true },
         )
-      : getServerSupabase();
+      : await getServerSupabase();
   }
 
   async isAuthenticated(): Promise<boolean> {
-    if (!this.supabaseClient) return false;
+    const supabase = await this.getSupabaseClient();
+    if (!supabase) return false;
     const {
       data: { session },
-    } = await this.supabaseClient.auth.getSession();
+    } = await supabase.auth.getSession();
     return session != null;
   }
 
@@ -726,9 +727,10 @@ export default class BackendAPI {
     const maxRetries = 3;
 
     while (retryCount < maxRetries) {
+      const supabase = await this.getSupabaseClient();
       const {
         data: { session },
-      } = (await this.supabaseClient?.auth.getSession()) || {
+      } = (await supabase?.auth.getSession()) || {
         data: { session: null },
       };
 
@@ -779,9 +781,10 @@ export default class BackendAPI {
     const maxRetries = 3;
 
     while (retryCount < maxRetries) {
+      const supabase = await this.getSupabaseClient();
       const {
         data: { session },
-      } = (await this.supabaseClient?.auth.getSession()) || {
+      } = (await supabase?.auth.getSession()) || {
         data: { session: null },
       };
 
@@ -956,9 +959,9 @@ export default class BackendAPI {
   async connectWebSocket(): Promise<void> {
     return (this.wsConnecting ??= new Promise(async (resolve, reject) => {
       try {
+        const supabase = await this.getSupabaseClient();
         const token =
-          (await this.supabaseClient?.auth.getSession())?.data.session
-            ?.access_token || "";
+          (await supabase?.auth.getSession())?.data.session?.access_token || "";
         const wsUrlWithToken = `${this.wsUrl}?token=${token}`;
         this.webSocket = new WebSocket(wsUrlWithToken);
         this.webSocket.state = "connecting";

--- a/autogpt_platform/frontend/src/lib/supabase/getServerSupabase.ts
+++ b/autogpt_platform/frontend/src/lib/supabase/getServerSupabase.ts
@@ -1,10 +1,10 @@
 import type { UnsafeUnwrappedCookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 
-export default function getServerSupabase() {
+export default async function getServerSupabase() {
   // Need require here, so Next.js doesn't complain about importing this on client side
   const { cookies } = require("next/headers");
-  const cookieStore = cookies() as UnsafeUnwrappedCookies;
+  const cookieStore = (await cookies()) as UnsafeUnwrappedCookies;
 
   try {
     const supabase = createServerClient(
@@ -12,11 +12,13 @@ export default function getServerSupabase() {
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       {
         cookies: {
-          getAll() {
+          getAll: async () => {
+            const cookieStore = await cookies();
             return cookieStore.getAll();
           },
-          setAll(cookiesToSet) {
+          setAll: async (cookiesToSet) => {
             try {
+              const cookieStore = await cookies();
               cookiesToSet.forEach(({ name, value, options }) =>
                 cookieStore.set(name, value, options),
               );

--- a/autogpt_platform/frontend/src/lib/supabase/getServerUser.ts
+++ b/autogpt_platform/frontend/src/lib/supabase/getServerUser.ts
@@ -1,7 +1,7 @@
 import getServerSupabase from "./getServerSupabase";
 
 const getServerUser = async () => {
-  const supabase = getServerSupabase();
+  const supabase = await getServerSupabase();
 
   if (!supabase) {
     return { user: null, error: "Failed to create Supabase client" };


### PR DESCRIPTION
## Summary
- update Supabase helper to await new async cookies API
- adjust server actions and routes to await `getServerSupabase`
- refactor BackendAPI client to fetch Supabase client asynchronously
- run `pnpm format` and `pnpm test`

## Testing
- `pnpm format`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_684e4f2e4be483208269d506ff2d86be